### PR TITLE
Add notes regarding usage on homebridge-docker instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,30 @@ See original code here: https://github.com/markwj/homebridge-pi
 }
 ```
 
-Fields:
+## With [homebridge-docker]()
+
+You can use the following configuration:
+
+```json
+{
+  "accessory": "LinuxDiskUsage",
+  "name": "Root disk usage",
+  "diskdevice": "/homebridge"
+}
+```
+
+If any issues appear, run the `df` command within the docker container using `docker exec homebridge df` and make sure your docker container root is `/homebridge`. Example output:
+
+```bash
+root@raspberrypi:/opt/docker/homebridge# docker exec homebridge df
+Filesystem     1K-blocks     Used Available Use% Mounted on
+overlay         61100032 37322064  21251984  64% /
+tmpfs              65536        0     65536   0% /dev
+tmpfs            1942148        0   1942148   0% /sys/fs/cgroup
+/dev/mmcblk0p2  61100032 37322064  21251984  64% /homebridge
+```
+
+## Fields
 
 * `accessory` must be "LinuxDiskUsage" (required).
 * `name` is the name of the published accessory (required).


### PR DESCRIPTION
After configuring the accessory in Homebridge, the following warnings appeared:

> [4/3/2022, 4:22:57 PM] [homebridge-linux-diskusage] This plugin generated a warning from the characteristic 'Current Relative Humidity': characteristic value expected valid finite number and received "NaN" (number). See https://git.io/JtMGR for more info.

This is the configuration I've used:

```json
{
  "accessory": "LinuxDiskUsage",
  "name": "Root disk usage",
  "diskdevice": "/dev/mmcblk0p2"
}
```

I've used `/dev/mmcblk0p2` after running `df` inside the container (`docker exec homebridge df`):

```
Filesystem     1K-blocks     Used Available Use% Mounted on
overlay         61100032 37322064  21251984  64% /
tmpfs              65536        0     65536   0% /dev
tmpfs            1942148        0   1942148   0% /sys/fs/cgroup
/dev/mmcblk0p2  61100032 37322064  21251984  64% /homebridge
```

Turns out this somewhat doesn't work. But using its filesystem mount `/homebridge` works.

```json
{
  "accessory": "LinuxDiskUsage",
  "name": "Root disk usage",
  "diskdevice": "/homebridge"
}
```

Tested the same config on another docker instance, no issues. So I'm guessing this should work on all home bridge-docker instances.